### PR TITLE
Build against fdk-aac from runtime

### DIFF
--- a/org.videolan.VLC.Plugin.fdkaac.json
+++ b/org.videolan.VLC.Plugin.fdkaac.json
@@ -14,29 +14,6 @@
   },
   "modules": [
     {
-      "name": "fdkaac",
-      "config-opts": [
-        "--with-pic",
-        "--disable-static",
-        "--enable-shared",
-        "--prefix=/app/share/vlc/extra/fdkaac"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/mstorsjo/fdk-aac/archive/v0.1.6.tar.gz",
-          "sha256": "adbcd793e406e1b88b3c1c41382d49f8c27371485b823c0fdab69c9124fd2ce3"
-        },
-        {
-          "type": "script",
-          "commands": [
-            "autoreconf -fiv"
-          ],
-          "dest-filename": "autogen.sh"
-        }
-      ]
-    },
-    {
       "name": "vlc",
       "rm-configure": true,
       "build-options": {
@@ -58,8 +35,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.videolan.org/pub/videolan/vlc/3.0.5/vlc-3.0.5.tar.xz",
-          "sha256": "f5c087dfebd4827052bf3b97996b3a05c79ae336dcb60a9e8d1a010f270072db"
+          "url": "https://download.videolan.org/pub/videolan/vlc/3.0.8/vlc-3.0.8.tar.xz",
+          "sha256": "e0149ef4a20a19b9ecd87309c2d27787ee3f47dfd47c6639644bc1f6fd95bdf6"
         },
         {
           "type": "file",

--- a/org.videolan.VLC.Plugin.fdkaac.json
+++ b/org.videolan.VLC.Plugin.fdkaac.json
@@ -16,9 +16,6 @@
     {
       "name": "vlc",
       "rm-configure": true,
-      "build-options": {
-        "append-pkg-config-path": "/app/share/vlc/extra/fdkaac/lib/pkgconfig"
-      },
       "config-opts": [
         "BUILDCC=/usr/bin/gcc -std=gnu99",
         "--disable-a52",


### PR DESCRIPTION
Also update vlc to 3.0.8. Fixes https://github.com/flathub/org.videolan.VLC.Plugin.fdkaac/issues/4